### PR TITLE
fix: Search bar fix to clear search when navigating away

### DIFF
--- a/components/globals/Navbar.tsx
+++ b/components/globals/Navbar.tsx
@@ -124,6 +124,10 @@ const Navbar = () => {
   useEffect(() => {
     setMenuOpen(false);
     setProfileMenuOpen(false);
+    if (!pathname.startsWith("/browse")) {
+      setSearchValue("");
+      setSuggestions([]);
+    }
   }, [pathname]);
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

- When a user navigates away from /browse (e.g. to Home, a listing page, profile, etc.), the navbar search bar is now automatically cleared
- Search term persists while the user stays on /browse to refine results
- Suggestions dropdown is also cleared on navigation

### What changed
`components/globals/Navbar.tsx` -> Added `setSearchValue("")` and `setSuggestions([])` to the existing pathname effect, conditioned on the user leaving `/browse`.